### PR TITLE
Hebrew parser prototype

### DIFF
--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -5,12 +5,12 @@ var _ = require('underscore');
 module.exports = {
   titles: {
     objective: ['objective', 'objectives'],
-    summary: ['summary'],
-    technology: ['technology', 'technologies'],
-    experience: ['experience'],
-    education: ['education'],
-    skills: ['skills', 'Skills & Expertise', 'technology', 'technologies'],
-    languages: ['languages'],
+    summary: ['summary', 'תמצית'],
+    experience: ['experience' ,'נסיון', 'נסיון תעסוקתי', 'נסיון מקצועי'],
+    education: ['education', 'השכלה', 'קורס מקצועי', 'קורסים', 'הסמכות'],
+    army: ['שירות צבאי', 'צבא'],
+    skills: ['skills', 'Skills & Expertise', 'technology', 'technologies', 'ידע מקצועי', 'כישורים', 'שפות תכנות'],
+    languages: ['languages', 'שפות'],
     courses: ['courses'],
     projects: ['projects'],
     links: ['links'],


### PR DESCRIPTION
The hebrew parser is currently able to parse hebrew PDF & DOC files.
I've added some popular keywords from developer resumes to the dictionary (which is being used to capture text blocks between headings)
## Requirements

**PDF parsing** is done by [Xpdf](http://www.foolabs.com/xpdf/download.html) & it's hebrew language support package (included in xpdf's homepage). After installation, change xpdf's default text encoding to UTF-8.

**DOC parsing** is done by [catdoc](https://www.wagner.pp.ru/~vitus/software/catdoc/), **_unless on OS X**_ in which case `textutil` is being used.
